### PR TITLE
Add simple Flask chatbot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-- 👋 Hi, I’m @thhech
-- 👀 I’m interested in Python
-- 🌱 I’m currently learning Advance analytic 
-- 💞️ I’m looking to collaborate on ML and AI
-- 📫 How to reach me ...
+# Webbaseret Chatbot
 
-<!---
-thhech/thhech is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Dette er et simpelt eksempel på en webbaseret chatbot bygget med Flask.
+
+## Kørsel
+
+1. Installer afhængigheder (f.eks. via `pip install flask`).
+2. Start serveren:
+   ```bash
+   python app.py
+   ```
+3. Åbn derefter `http://localhost:5000` i din browser og chat løs.
+
+Chatbotten svarer med et par enkle regler og kan bruges som et udgangspunkt for videre udvikling.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, request, jsonify, render_template
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/chat', methods=['POST'])
+def chat():
+    data = request.get_json()
+    user_message = data.get('message', '')
+    reply = generate_reply(user_message)
+    return jsonify({'reply': reply})
+
+
+def generate_reply(message: str) -> str:
+    message = message.strip().lower()
+    if not message:
+        return "Jeg forstod ikke beskeden."
+    if 'hej' in message:
+        return "Hej med dig! Hvordan kan jeg hjælpe?"
+    if 'farvel' in message:
+        return "Farvel!"
+    return "Jeg er en simpel chatbot."
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,23 @@
+async function sendMessage() {
+    const input = document.getElementById('input');
+    const text = input.value;
+    if (!text) return;
+
+    appendMessage('Du', text);
+    input.value = '';
+
+    const response = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+    });
+    const data = await response.json();
+    appendMessage('Bot', data.reply);
+}
+
+function appendMessage(sender, text) {
+    const messages = document.getElementById('messages');
+    const div = document.createElement('div');
+    div.textContent = `${sender}: ${text}`;
+    messages.appendChild(div);
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="da">
+<head>
+    <meta charset="utf-8">
+    <title>Chatbot Demo</title>
+    <script src="/static/script.js"></script>
+</head>
+<body>
+    <h1>Webbaseret Chatbot</h1>
+    <div id="chat">
+        <div id="messages"></div>
+        <input type="text" id="input" placeholder="Skriv en besked" />
+        <button onclick="sendMessage()">Send</button>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a minimal Flask app that implements a basic rule-based chatbot
- provide a simple frontend with HTML and JavaScript
- update README with setup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68428ff80ac483268300c0d1928a6d40